### PR TITLE
Added Easy Open Cv to dependencies in TeamCode/build.gradle, removed references to arm64-v8a from build.common…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ That's it. `gradlew` is a script that downloads Gradle and runs the commands for
 
 ### Lagtränare (Team coach)
 1. Rob Lingstuyl
+
+# libOpenCvAndroid453.so
+For Easy Open Cv to work you have to download the libOpenCvAndroid453.so file and copy it to the robot controller; you can find download and further instructions [here](https://github.com/OpenFTC/EasyOpenCV)

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -21,4 +21,7 @@ dependencies {
 
     // Road runner
     implementation 'com.acmerobotics.roadrunner:core:0.5.3'
+
+    // Easy open cv
+    implementation 'org.openftc:easyopencv:1.5.0'
 }

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -94,7 +94,7 @@ android {
             signingConfig signingConfigs.release
 
             ndk {
-                abiFilters "armeabi-v7a", "arm64-v8a"
+                abiFilters "armeabi-v7a"
             }
         }
         debug {
@@ -102,7 +102,7 @@ android {
             jniDebuggable true
             renderscriptDebuggable true
             ndk {
-                abiFilters "armeabi-v7a", "arm64-v8a"
+                abiFilters "armeabi-v7a"
             }
         }
     }


### PR DESCRIPTION
...gradle, and added instructions for adding the libOpenCvAndroid453.so file to the robot controller (required for Easy Open Cv to work) to README.md


