### PR TITLE
Added correct jdk instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ Because of the nature of the FTC Tech Challenge (yes, I know, [RAS syndome](http
 However, if you are an enterprising person, you may want to do things "the old-fashioned way", and use the command line. Lucky for us, Gradle is a command-line tool (in fact, Android Studio calls it). You can find the official documentation for building a Gradle project from the command line [here](https://spring.io/guides/gs/gradle/). For your convenience, we have listed the steps below!
 
 ```bash
+# The only step you need to do to compile your code again is the ./gradlew builds command.
+# If this is your first time, follow the instructions below.
+# Check your java version
+
+java --version
+
+# If you have anything other than verison 11, you will need to install it, because Java is
+# Java. Fear not, this is a simple process. If 11 is installed, skip to the bottom.
+
+# First, we install a tool that lets you manage your Java versions.
+curl -s "https://get.sdkman.io" | bash
+echo source \"$HOME/.sdkman/bin/sdkman-init.sh\" >> ~/.$(basename $SHELL)rc
+source ~/.$(basename $SHELL)rc
+
+# Next, you can install JDK 11 (what we want)
+sdk install java 11.0.11.hs-adpt
+
+# You should now be good to go! If you encountered any errors, please email/text/contact:
+#   Milo Banks <milobanks@rowlandhall.org>
+
 ./gradlew build
 ```
 


### PR DESCRIPTION
Multiple people had trouble with JDK 16, and I forgot to tell them how to compile for JDK 11. In the README are new instructions on how to set up the first build.