### PR TITLE
Moved most code into org.rowlandhall.arc package

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/AutonomousMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/AutonomousMode.java
@@ -1,10 +1,10 @@
-package org.firstinspires.ftc.teamcode;
+package org.rowlandhall.arc;
 
 import com.qualcomm.robotcore.eventloop.opmode.*;
 
-import org.firstinspires.ftc.teamcode.logging.*;
-import org.firstinspires.ftc.teamcode.autonomous.sensor.webcam.Webcam;
-import org.firstinspires.ftc.teamcode.autonomous.sensor.webcam.WebcamPipeline;
+import org.rowlandhall.arc.logging.*;
+import org.rowlandhall.arc.autonomous.sensor.webcam.Webcam;
+import org.rowlandhall.arc.autonomous.sensor.webcam.WebcamPipeline;
 
 import org.firstinspires.ftc.robotcore.external.hardware.camera.WebcamName;
 import org.firstinspires.ftc.robotcore.external.Telemetry;

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/collision/CollisionDetector.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/collision/CollisionDetector.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.autonomous.collision;
+package org.rowlandhall.arc.autonomous.collision;
 
 /** Class to detect collisions. */
 public class CollisionDetector {

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/collision/CollisionResponse.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/collision/CollisionResponse.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.autonomous.collision;
+package org.rowlandhall.arc.autonomous.collision;
 
 /** Class to response to collisions. */
 public class CollisionResponse<Distance> {

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/Entity.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/Entity.java
@@ -1,6 +1,6 @@
-package org.firstinspires.ftc.teamcode.autonomous.environment;
+package org.rowlandhall.arc.autonomous.environment;
 
-import org.firstinspires.ftc.teamcode.autonomous.environment.EntityType;
+import org.rowlandhall.arc.autonomous.environment.EntityType;
 
 public abstract class Entity {
     /** The x coordinate of our entity. */

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/EntityType.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/EntityType.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.autonomous.environment;
+package org.rowlandhall.arc.autonomous.environment;
 
 /** Enum containing all the possible things we could detect. */
 public enum EntityType {

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/EnvironmentMap.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/EnvironmentMap.java
@@ -1,11 +1,11 @@
-package org.firstinspires.ftc.teamcode.autonomous.environment;
+package org.rowlandhall.arc.autonomous.environment;
 
 import java.util.ArrayList;
 
-import org.firstinspires.ftc.teamcode.autonomous.environment.NoActiveEntityException;
-import org.firstinspires.ftc.teamcode.autonomous.environment.Entity;
-import org.firstinspires.ftc.teamcode.autonomous.environment.EntityType;
-import org.firstinspires.ftc.teamcode.autonomous.environment.RobotEntity;
+import org.rowlandhall.arc.autonomous.environment.NoActiveEntityException;
+import org.rowlandhall.arc.autonomous.environment.Entity;
+import org.rowlandhall.arc.autonomous.environment.EntityType;
+import org.rowlandhall.arc.autonomous.environment.RobotEntity;
 
 /** A wrapper for a list of entities. Provides a useful API for code abstraction, along
  * wth making the code easier for less advanced developers. */

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/EnvironmentMapError.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/EnvironmentMapError.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.autonomous.environment;
+package org.rowlandhall.arc.autonomous.environment;
 
 class NoActiveEntityException extends Exception {
     public NoActiveEntityException() { }

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/GenericEntity.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/GenericEntity.java
@@ -1,7 +1,7 @@
-package org.firstinspires.ftc.teamcode.autonomous.environment;
+package org.rowlandhall.arc.autonomous.environment;
 
-import org.firstinspires.ftc.teamcode.autonomous.environment.Entity;
-import org.firstinspires.ftc.teamcode.autonomous.environment.EntityType;
+import org.rowlandhall.arc.autonomous.environment.Entity;
+import org.rowlandhall.arc.autonomous.environment.EntityType;
 
 /** A generic entity. Used mostly for testing, but should be in
  * the main source tree as it's not actually a test itself. */

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/RobotEntity.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/RobotEntity.java
@@ -1,7 +1,7 @@
-package org.firstinspires.ftc.teamcode.autonomous.environment;
+package org.rowlandhall.arc.autonomous.environment;
 
-import org.firstinspires.ftc.teamcode.autonomous.environment.Entity;
-import org.firstinspires.ftc.teamcode.autonomous.environment.EntityType;
+import org.rowlandhall.arc.autonomous.environment.Entity;
+import org.rowlandhall.arc.autonomous.environment.EntityType;
 
 public class RobotEntity extends Entity {
     boolean active;

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/Sensor.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/Sensor.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.autonomous.sensor;
+package org.rowlandhall.arc.autonomous.sensor;
 
 /** An interface that all sensors should implement. This is mainly 
  * just for convience */

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/imu/IMUStream.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/imu/IMUStream.java
@@ -1,6 +1,6 @@
-package org.firstinspires.ftc.teamcode.autonomous.sensor.imu;
+package org.rowlandhall.arc.autonomous.sensor.imu;
 
-import org.firstinspires.ftc.teamcode.autonomous.sensor.Sensor;
+import org.rowlandhall.arc.autonomous.sensor.Sensor;
 
 /** Class for interacting with the onboard IMU sensor. */
 public class IMUStream implements Sensor {

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/ir/IRStream.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/ir/IRStream.java
@@ -1,6 +1,6 @@
-package org.firstinspires.ftc.teamcode.autonomous.sensor.ir;
+package org.rowlandhall.arc.autonomous.sensor.ir;
 
-import org.firstinspires.ftc.teamcode.autonomous.sensor.Sensor;
+import org.rowlandhall.arc.autonomous.sensor.Sensor;
 
 /** Class for interacting with an IR sensor. */
 public class IRStream implements Sensor {

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/webcam/Webcam.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/webcam/Webcam.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.autonomous.sensor.webcam;
+package org.rowlandhall.arc.autonomous.sensor.webcam;
 
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
@@ -9,9 +9,9 @@ import org.openftc.easyopencv.OpenCvCameraRotation;
 import org.openftc.easyopencv.OpenCvPipeline;
 import org.openftc.easyopencv.OpenCvWebcam;
 
-import org.firstinspires.ftc.teamcode.logging.*;
-import org.firstinspires.ftc.teamcode.AutonomousMode;
-import org.firstinspires.ftc.teamcode.autonomous.sensor.Sensor;
+import org.rowlandhall.arc.logging.*;
+import org.rowlandhall.arc.AutonomousMode;
+import org.rowlandhall.arc.autonomous.sensor.Sensor;
 
 /** Class for interacting (and quasi-processing) of webcame data. */
 public class Webcam implements Sensor {

--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/webcam/WebcamPipeline.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/sensor/webcam/WebcamPipeline.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.autonomous.sensor.webcam;
+package org.rowlandhall.arc.autonomous.sensor.webcam;
 
 import org.opencv.core.Mat;
 import org.opencv.core.Point;

--- a/TeamCode/src/main/java/org/rowlandhall/arc/logging/Logging.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/logging/Logging.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.logging;
+package org.rowlandhall.arc.logging;
 
 import android.annotation.SuppressLint;
 import com.qualcomm.robotcore.util.RobotLog;

--- a/TeamCode/src/main/java/org/rowlandhall/arc/logging/LoggingLevel.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/logging/LoggingLevel.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.logging;
+package org.rowlandhall.arc.logging;
 
 /** A logging level. */
 public enum LoggingLevel {

--- a/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/autonomous/environment/EntityTypeTest.java
+++ b/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/autonomous/environment/EntityTypeTest.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.environment.test;
+package org.rowlandhall.arc.environment.test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
-import org.firstinspires.ftc.teamcode.autonomous.environment.EntityType;
+import org.rowlandhall.arc.autonomous.environment.EntityType;
 
 class EntityTypeTest {
     @Test

--- a/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/autonomous/environment/EnvironmentMapTest.java
+++ b/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/autonomous/environment/EnvironmentMapTest.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.environment.test;
+package org.rowlandhall.arc.environment.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
-import org.firstinspires.ftc.teamcode.autonomous.environment.EnvironmentMap;
-import org.firstinspires.ftc.teamcode.autonomous.environment.GenericEntity;
-import org.firstinspires.ftc.teamcode.autonomous.environment.RobotEntity;
-import org.firstinspires.ftc.teamcode.autonomous.environment.Entity;
+import org.rowlandhall.arc.autonomous.environment.EnvironmentMap;
+import org.rowlandhall.arc.autonomous.environment.GenericEntity;
+import org.rowlandhall.arc.autonomous.environment.RobotEntity;
+import org.rowlandhall.arc.autonomous.environment.Entity;
 
 import java.util.ArrayList;
 

--- a/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/autonomous/environment/GenericEntityTest.java
+++ b/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/autonomous/environment/GenericEntityTest.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.environment.test;
+package org.rowlandhall.arc.environment.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
-import org.firstinspires.ftc.teamcode.autonomous.environment.GenericEntity;
-import org.firstinspires.ftc.teamcode.autonomous.environment.EntityType;
+import org.rowlandhall.arc.autonomous.environment.GenericEntity;
+import org.rowlandhall.arc.autonomous.environment.EntityType;
 
 import java.io.FileWriter;
 import java.io.IOException;

--- a/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/autonomous/environment/RobotEntityTest.java
+++ b/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/autonomous/environment/RobotEntityTest.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.environment.test;
+package org.rowlandhall.arc.environment.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
-import org.firstinspires.ftc.teamcode.autonomous.environment.RobotEntity;
-import org.firstinspires.ftc.teamcode.autonomous.environment.EntityType;
+import org.rowlandhall.arc.autonomous.environment.RobotEntity;
+import org.rowlandhall.arc.autonomous.environment.EntityType;
 
 class RobotEntityTest {
     RobotEntity entity;


### PR DESCRIPTION
Basically all code is suppose to be written in the `org.firstinspires.ftc.teamcode` package, but this is a problem if everyone's package is named this.

It also makes it easier to see which code belongs to us.

We moved the main code (but not the opmodes, they have to stay in `org.firstinspires.ftc.teamcode`) to `org.rowlandhall.arc`.