### PR TITLE
Fixed void constructor

### DIFF
--- a/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/EnvironmentMap.java
+++ b/TeamCode/src/main/java/org/rowlandhall/arc/autonomous/environment/EnvironmentMap.java
@@ -18,7 +18,7 @@ public class EnvironmentMap {
 
     /** Constructor for the environment map. Takes no arguments, as these
      * should be loaded and unloaded dynamically at runtime. */
-    public void EnvironmentMap() {
+    public EnvironmentMap() {
         this.last_time_since_epoch = System.currentTimeMillis();
     }
 


### PR DESCRIPTION
Fixed void constructor. Example:

```java
public void Foo();
```

We don't want the void in there, because then it's not technically a constructor.

```java
public Foo();
```